### PR TITLE
Fix crash on startup with Gtk >= 4.17

### DIFF
--- a/granite-init.patch
+++ b/granite-init.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 4c5ce6b..3f30309 100644
+index 8369478..39358d8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -28,6 +28,7 @@ libadwaita_req_version = '>= 1.2.alpha'
+@@ -28,6 +28,7 @@ libadwaita_req_version = '>= 1.5'
  harfbuzz_req_version = '>= 0.9.9'
  
  glib_dep = dependency('glib-2.0', version: glib_req_version)
@@ -11,31 +11,35 @@ index 4c5ce6b..3f30309 100644
  libadwaita_dep = dependency('libadwaita-1', version: libadwaita_req_version)
  harfbuzz_dep = dependency('harfbuzz', version: harfbuzz_req_version)
 diff --git a/src/font-view-application.c b/src/font-view-application.c
-index 7dd050f..d097d04 100644
+index 90f5488..47a4221 100644
 --- a/src/font-view-application.c
 +++ b/src/font-view-application.c
-@@ -163,6 +163,7 @@ font_view_application_activate (GApplication *application)
- static void
- font_view_application_init (FontViewApplication *self)
- {
-+    granite_init ();
-     /* do nothing */
- }
- 
-diff --git a/src/font-view-application.h b/src/font-view-application.h
-index dcf1c48..bd98e26 100644
---- a/src/font-view-application.h
-+++ b/src/font-view-application.h
-@@ -24,6 +24,7 @@
- #pragma once
- 
- #include <adwaita.h>
+@@ -38,6 +38,7 @@
+ #include <hb-ot.h>
+ #include <hb.h>
+ #include <libadwaita-1/adwaita.h>
 +#include <granite-7.h>
  
- G_BEGIN_DECLS
+ #include "font-view-application.h"
+ #include "font-view-window.h"
+@@ -141,6 +142,15 @@ font_view_application_startup (GApplication *application)
+ {
+     FontViewApplication *self = FONT_VIEW_APPLICATION (application);
+ 
++    // granite_init() calls gdk_display_manager_get() internally without
++    // initializing Gtk, which is illegal and causes an intentional
++    // crash since Gtk 4.17. So, initialize Gtk explicitly here as a
++    // workaround.
++    // TODO: Remove this when https://github.com/elementary/granite/pull/893 is released
++    gtk_init ();
++
++    granite_init ();
++
+     G_APPLICATION_CLASS (font_view_application_parent_class)
+         ->startup (application);
  
 diff --git a/src/meson.build b/src/meson.build
-index c0cc0a8..42fc454 100644
+index ce70bfe..8a96129 100644
 --- a/src/meson.build
 +++ b/src/meson.build
 @@ -38,6 +38,7 @@ executable('gnome-font-viewer', viewer_sources + resources,


### PR DESCRIPTION
- Fix crash on startup
- Include granite.h in the .c file because it's not used in the .h file
- Call `granite_init()` in `startup()` instead of the constructor
